### PR TITLE
feat: add 5 pages, routing, and easter egg integration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.0.0",
       "dependencies": {
         "react": "^19.2.4",
-        "react-dom": "^19.2.4"
+        "react-dom": "^19.2.4",
+        "react-router-dom": "^7.14.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.4",
@@ -1998,6 +1999,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -3415,6 +3429,44 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/react-router": {
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.14.0.tgz",
+      "integrity": "sha512-m/xR9N4LQLmAS0ZhkY2nkPA1N7gQ5TUVa5n8TgANuDTARbn1gt+zLPXEm7W0XDTbrQ2AJSJKhoa6yx1D8BcpxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.14.0.tgz",
+      "integrity": "sha512-2G3ajSVSZMEtmTjIklRWlNvo8wICEpLihfD/0YMDxbWK2UyP5EGfnoIn9AIQGnF3G/FX0MRbHXdFcD+rL1ZreQ==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.14.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -3518,6 +3570,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   },
   "dependencies": {
     "react": "^19.2.4",
-    "react-dom": "^19.2.4"
+    "react-dom": "^19.2.4",
+    "react-router-dom": "^7.14.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",

--- a/src/App.module.css
+++ b/src/App.module.css
@@ -1,0 +1,24 @@
+.app {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+.main {
+  flex: 1;
+}
+
+.footer {
+  margin-top: auto;
+}
+
+.footerExtras {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-4);
+  padding: var(--space-2) var(--space-4);
+  font-family: var(--font-ui);
+  font-size: var(--text-sm);
+  color: var(--color-text-muted);
+}

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,0 +1,98 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter, Link as RouterLink } from 'react-router-dom'
+import { ThemeProvider } from './foundation/ThemeProvider'
+import { Routes, Route, useLocation } from 'react-router-dom'
+import { NavBar } from './components/NavBar'
+import { Container } from './foundation/Container'
+import { HomePage } from './pages/HomePage'
+import { PortfolioPage } from './pages/PortfolioPage'
+import { SpeakingPage } from './pages/SpeakingPage'
+import { CommunityPage } from './pages/CommunityPage'
+import { ConnectPage } from './pages/ConnectPage'
+
+const NAV_LINKS = [
+  { label: 'Home', href: '/' },
+  { label: 'Portfolio', href: '/portfolio' },
+  { label: 'Speaking', href: '/speaking' },
+  { label: 'Community', href: '/community' },
+  { label: 'Connect', href: '/connect' },
+]
+
+function TestApp({ initialPath = '/' }: { initialPath?: string }) {
+  return (
+    <MemoryRouter initialEntries={[initialPath]}>
+      <ThemeProvider>
+        <TestLayout />
+      </ThemeProvider>
+    </MemoryRouter>
+  )
+}
+
+function TestLayout() {
+  const location = useLocation()
+  return (
+    <>
+      <NavBar links={NAV_LINKS} currentPath={location.pathname} siteName="Andrew Harasymiw" linkComponent={RouterLink} />
+      <main id="main">
+        <Routes>
+          <Route path="/" element={<HomePage />} />
+          <Route path="/portfolio" element={<PortfolioPage />} />
+          <Route path="/speaking" element={<SpeakingPage />} />
+          <Route path="/community" element={<CommunityPage />} />
+          <Route path="/connect" element={<ConnectPage />} />
+          <Route path="*" element={<Container><p>404</p><RouterLink to="/">Go home</RouterLink></Container>} />
+        </Routes>
+      </main>
+    </>
+  )
+}
+
+describe('App routing', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    document.documentElement.removeAttribute('data-theme')
+  })
+
+  it('renders homepage at /', () => {
+    render(<TestApp />)
+    expect(screen.getByText("Let's build together.")).toBeInTheDocument()
+  })
+
+  it('renders portfolio at /portfolio', () => {
+    render(<TestApp initialPath="/portfolio" />)
+    expect(screen.getByRole('heading', { name: 'Portfolio' })).toBeInTheDocument()
+  })
+
+  it('renders speaking page at /speaking', () => {
+    render(<TestApp initialPath="/speaking" />)
+    expect(screen.getByRole('heading', { name: 'Speaking & Education' })).toBeInTheDocument()
+  })
+
+  it('renders community page at /community', () => {
+    render(<TestApp initialPath="/community" />)
+    expect(screen.getByRole('heading', { name: 'Community', level: 1 })).toBeInTheDocument()
+  })
+
+  it('renders connect page at /connect', () => {
+    render(<TestApp initialPath="/connect" />)
+    expect(screen.getByRole('heading', { name: "Let's Connect" })).toBeInTheDocument()
+  })
+
+  it('highlights current page in nav', () => {
+    render(<TestApp initialPath="/portfolio" />)
+    const portfolioLink = screen.getByRole('link', { name: 'Portfolio' })
+    expect(portfolioLink).toHaveAttribute('aria-current', 'page')
+  })
+
+  it('does not highlight non-current pages', () => {
+    render(<TestApp initialPath="/portfolio" />)
+    const homeLink = screen.getByRole('link', { name: 'Home' })
+    expect(homeLink).not.toHaveAttribute('aria-current')
+  })
+
+  it('renders 404 for unknown routes', () => {
+    render(<TestApp initialPath="/nonexistent" />)
+    expect(screen.getByText('404')).toBeInTheDocument()
+    expect(screen.getByText('Go home')).toBeInTheDocument()
+  })
+})

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,3 +1,96 @@
+import { useEffect } from 'react'
+import { BrowserRouter, Routes, Route, useLocation, Link as RouterLink } from 'react-router-dom'
+import { ThemeProvider } from './foundation/ThemeProvider'
+import { SkipLink } from './foundation/SkipLink'
+import { NavBar } from './components/NavBar'
+import { Footer } from './components/Footer'
+import { KonamiConfetti } from './playground/KonamiConfetti'
+import { GravySnail } from './playground/GravySnail'
+import { PartyMode } from './playground/PartyMode'
+import { FooterTaglines } from './playground/FooterTaglines'
+import { HomePage } from './pages/HomePage'
+import { PortfolioPage } from './pages/PortfolioPage'
+import { SpeakingPage } from './pages/SpeakingPage'
+import { CommunityPage } from './pages/CommunityPage'
+import { ConnectPage } from './pages/ConnectPage'
+import styles from './App.module.css'
+
+const NAV_LINKS = [
+  { label: 'Home', href: '/' },
+  { label: 'Portfolio', href: '/portfolio' },
+  { label: 'Speaking', href: '/speaking' },
+  { label: 'Community', href: '/community' },
+  { label: 'Connect', href: '/connect' },
+]
+
+const FOOTER_TAGLINES = [
+  'Made with caffeine and natural 20s',
+  'No frameworks were harmed',
+  'Mass-produced by mass-producing machines',
+  'Debugged by Gravy the snail',
+  'Achievement unlocked: read the footer',
+]
+
+function NotFound() {
+  return (
+    <div style={{ textAlign: 'center', padding: 'var(--space-9) var(--space-4)' }}>
+      <h1 style={{ fontFamily: 'var(--font-heading)', fontWeight: 300, fontSize: 'var(--text-3xl)' }}>
+        404
+      </h1>
+      <p style={{ fontFamily: 'var(--font-body)', color: 'var(--color-text-muted)', marginTop: 'var(--space-4)' }}>
+        This page doesn't exist. Maybe Gravy ate it.
+      </p>
+      <RouterLink to="/" style={{ color: 'var(--color-accent-green)', fontFamily: 'var(--font-ui)', marginTop: 'var(--space-4)', display: 'inline-block' }}>
+        Go home
+      </RouterLink>
+    </div>
+  )
+}
+
+function AppLayout() {
+  const location = useLocation()
+  useEffect(() => {
+    window.scrollTo(0, 0)
+  }, [location.pathname])
+
+  return (
+    <div className={styles.app}>
+      <SkipLink />
+      <NavBar
+        links={NAV_LINKS}
+        currentPath={location.pathname}
+        siteName="Andrew Harasymiw"
+        linkComponent={RouterLink}
+      />
+      <main id="main" className={styles.main}>
+        <Routes>
+          <Route path="/" element={<HomePage />} />
+          <Route path="/portfolio" element={<PortfolioPage />} />
+          <Route path="/speaking" element={<SpeakingPage />} />
+          <Route path="/community" element={<CommunityPage />} />
+          <Route path="/connect" element={<ConnectPage />} />
+          <Route path="*" element={<NotFound />} />
+        </Routes>
+      </main>
+      <footer className={styles.footer}>
+        <Footer />
+        <div className={styles.footerExtras}>
+          <FooterTaglines year={new Date().getFullYear()} taglines={FOOTER_TAGLINES} />
+          <PartyMode />
+        </div>
+      </footer>
+      <KonamiConfetti />
+      <GravySnail />
+    </div>
+  )
+}
+
 export default function App() {
-  return <div>aharasymiw.com</div>
+  return (
+    <BrowserRouter>
+      <ThemeProvider>
+        <AppLayout />
+      </ThemeProvider>
+    </BrowserRouter>
+  )
 }

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -1,5 +1,6 @@
-import { useState } from 'react'
+import { useState, useCallback, type ComponentType } from 'react'
 import { useTheme } from '../foundation/ThemeProvider'
+import { SunsetTransition } from '../playground/SunsetTransition'
 import styles from './NavBar.module.css'
 
 interface NavLink {
@@ -11,11 +12,21 @@ interface NavBarProps {
   links: NavLink[]
   currentPath: string
   siteName: string
+  linkComponent?: ComponentType<{ to: string; className?: string; 'aria-current'?: 'page'; onClick?: () => void; children: React.ReactNode }>
 }
 
-export function NavBar({ links, currentPath, siteName }: NavBarProps) {
+export function NavBar({ links, currentPath, siteName, linkComponent: LinkComp }: NavBarProps) {
   const { theme, toggleTheme } = useTheme()
   const [mobileOpen, setMobileOpen] = useState(false)
+  const [sunsetActive, setSunsetActive] = useState(false)
+  const [sunsetDir, setSunsetDir] = useState<'dark' | 'light'>('dark')
+
+  const handleToggle = useCallback(() => {
+    setSunsetDir(theme === 'light' ? 'dark' : 'light')
+    setSunsetActive(true)
+    toggleTheme()
+    setTimeout(() => setSunsetActive(false), 350)
+  }, [theme, toggleTheme])
 
   return (
     <header className={styles.navbar}>
@@ -25,19 +36,29 @@ export function NavBar({ links, currentPath, siteName }: NavBarProps) {
         <ul className={styles.navLinks}>
           {links.map(link => (
             <li key={link.href}>
-              <a
-                href={link.href}
-                className={`${styles.navLink}${currentPath === link.href ? ` ${styles.navLinkActive}` : ''}`}
-                aria-current={currentPath === link.href ? 'page' : undefined}
-              >
-                {link.label}
-              </a>
+              {LinkComp ? (
+                <LinkComp
+                  to={link.href}
+                  className={`${styles.navLink}${currentPath === link.href ? ` ${styles.navLinkActive}` : ''}`}
+                  aria-current={currentPath === link.href ? 'page' : undefined}
+                >
+                  {link.label}
+                </LinkComp>
+              ) : (
+                <a
+                  href={link.href}
+                  className={`${styles.navLink}${currentPath === link.href ? ` ${styles.navLinkActive}` : ''}`}
+                  aria-current={currentPath === link.href ? 'page' : undefined}
+                >
+                  {link.label}
+                </a>
+              )}
             </li>
           ))}
           <li>
             <button
               className={styles.themeToggle}
-              onClick={toggleTheme}
+              onClick={handleToggle}
               aria-label={`Switch to ${theme === 'light' ? 'dark' : 'light'} theme`}
             >
               {theme === 'light' ? (
@@ -81,25 +102,38 @@ export function NavBar({ links, currentPath, siteName }: NavBarProps) {
             <path d="M18 6L6 18M6 6l12 12" />
           </svg>
         </button>
-        {links.map(link => (
-          <a
-            key={link.href}
-            href={link.href}
-            className={`${styles.mobileNavLink}${currentPath === link.href ? ` ${styles.mobileNavLinkActive}` : ''}`}
-            aria-current={currentPath === link.href ? 'page' : undefined}
-            onClick={() => setMobileOpen(false)}
-          >
-            {link.label}
-          </a>
-        ))}
+        {links.map(link =>
+          LinkComp ? (
+            <LinkComp
+              key={link.href}
+              to={link.href}
+              className={`${styles.mobileNavLink}${currentPath === link.href ? ` ${styles.mobileNavLinkActive}` : ''}`}
+              aria-current={currentPath === link.href ? 'page' : undefined}
+              onClick={() => setMobileOpen(false)}
+            >
+              {link.label}
+            </LinkComp>
+          ) : (
+            <a
+              key={link.href}
+              href={link.href}
+              className={`${styles.mobileNavLink}${currentPath === link.href ? ` ${styles.mobileNavLinkActive}` : ''}`}
+              aria-current={currentPath === link.href ? 'page' : undefined}
+              onClick={() => setMobileOpen(false)}
+            >
+              {link.label}
+            </a>
+          )
+        )}
         <button
           className={styles.themeToggle}
-          onClick={toggleTheme}
+          onClick={handleToggle}
           aria-label={`Switch to ${theme === 'light' ? 'dark' : 'light'} theme`}
         >
           {theme === 'light' ? '🌙' : '☀️'}
         </button>
       </div>
+      <SunsetTransition active={sunsetActive} direction={sunsetDir} />
     </header>
   )
 }

--- a/src/pages/CommunityPage.module.css
+++ b/src/pages/CommunityPage.module.css
@@ -1,0 +1,40 @@
+.skillsGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: var(--space-4);
+  margin-top: var(--space-5);
+}
+
+.skillList {
+  list-style: none;
+  padding: 0;
+  font-family: var(--font-body);
+  line-height: 1.8;
+  color: var(--color-text);
+}
+
+.lessonList {
+  list-style: none;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  font-family: var(--font-body);
+  line-height: 1.6;
+  color: var(--color-text);
+  margin-top: var(--space-3);
+}
+
+.overlapGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: var(--space-4);
+  margin-top: var(--space-4);
+}
+
+@media (max-width: 768px) {
+  .skillsGrid,
+  .overlapGrid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/pages/CommunityPage.test.tsx
+++ b/src/pages/CommunityPage.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { ThemeProvider } from '../foundation/ThemeProvider'
+import { CommunityPage } from './CommunityPage'
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <ThemeProvider>
+        <CommunityPage />
+      </ThemeProvider>
+    </MemoryRouter>
+  )
+}
+
+describe('CommunityPage', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    document.documentElement.removeAttribute('data-theme')
+  })
+
+  it('renders the page heading', () => {
+    renderPage()
+    expect(screen.getByRole('heading', { name: 'Community', level: 1 })).toBeInTheDocument()
+  })
+
+  it('renders Toastmasters section', () => {
+    renderPage()
+    expect(screen.getByText('Toastmasters')).toBeInTheDocument()
+    expect(screen.getByText('Area Director (2021–2022)')).toBeInTheDocument()
+    expect(screen.getByText('Club President (2020–2021)')).toBeInTheDocument()
+  })
+
+  it('renders TTRPGs section', () => {
+    renderPage()
+    expect(screen.getByText(/Tabletop RPGs/)).toBeInTheDocument()
+    expect(screen.getByText('Dungeon Master (2014–Present)')).toBeInTheDocument()
+  })
+
+  it('renders D20Tumble elements for D&D references', () => {
+    renderPage()
+    expect(screen.getByText('Dungeons & Dragons')).toBeInTheDocument()
+  })
+
+  it('renders the professional overlap section', () => {
+    renderPage()
+    expect(screen.getByText('Where It All Connects')).toBeInTheDocument()
+  })
+
+  it('renders skills grid cards', () => {
+    renderPage()
+    expect(screen.getByText('Facilitation')).toBeInTheDocument()
+    expect(screen.getByText('Improvisation')).toBeInTheDocument()
+  })
+})

--- a/src/pages/CommunityPage.tsx
+++ b/src/pages/CommunityPage.tsx
@@ -1,0 +1,176 @@
+import { Container } from '../foundation/Container'
+import { Heading } from '../foundation/Heading'
+import { Text } from '../foundation/Text'
+import { Section } from '../components/Section'
+import { Card } from '../components/Card'
+import { Accordion, AccordionItem } from '../components/Accordion'
+import { RevealOnScroll } from '../playground/RevealOnScroll'
+import { D20Tumble } from '../playground/D20Tumble'
+import styles from './CommunityPage.module.css'
+
+export function CommunityPage() {
+  return (
+    <Container>
+      <Section>
+        <Heading level={1}>Community</Heading>
+        <Text>
+          Beyond technology, I'm passionate about creating inclusive communities where everyone
+          can contribute. Whether through public speaking events, gaming communities, or mentoring,
+          I focus on lowering barriers and amplifying voices.
+        </Text>
+      </Section>
+
+      <RevealOnScroll>
+        <Section zone="calm">
+          <Heading level={2}>Toastmasters</Heading>
+          <Text>
+            Since 2016, I've dedicated thousands of hours to honing my communication skills,
+            mentoring others, and leading at both club and area levels through Toastmasters International.
+          </Text>
+
+          <Accordion>
+            <AccordionItem title="Area Director (2021–2022)">
+              <Text>
+                Oversaw 4–5 clubs with over 80 total members. Organized area-level speech contests
+                and training events, conducted club visits, and achieved Distinguished Area recognition.
+              </Text>
+            </AccordionItem>
+            <AccordionItem title="Club President (2020–2021)">
+              <Text>
+                Led our club through the pandemic transition to virtual meetings, maintaining member
+                engagement and growing membership during uncertain times.
+              </Text>
+            </AccordionItem>
+            <AccordionItem title="Club Secretary (2018–2019)">
+              <Text>
+                Managed club administration and communications, ensuring smooth operations and
+                new member onboarding.
+              </Text>
+            </AccordionItem>
+            <AccordionItem title="Officer Mentor (2022–Present)">
+              <Text>
+                Ongoing guidance to new club officers, sharing best practices and helping them
+                navigate leadership challenges.
+              </Text>
+            </AccordionItem>
+          </Accordion>
+
+          <div className={styles.skillsGrid}>
+            <Card header={<Heading level={3} size="base">Communication</Heading>}>
+              <ul className={styles.skillList}>
+                <li>Clarity and structure</li>
+                <li>Audience engagement</li>
+                <li>Storytelling</li>
+                <li>Vocal variety</li>
+              </ul>
+            </Card>
+            <Card header={<Heading level={3} size="base">Leadership</Heading>}>
+              <ul className={styles.skillList}>
+                <li>Vision setting</li>
+                <li>Team building</li>
+                <li>Conflict resolution</li>
+                <li>Volunteer management</li>
+              </ul>
+            </Card>
+            <Card header={<Heading level={3} size="base">Evaluation</Heading>}>
+              <ul className={styles.skillList}>
+                <li>Active listening</li>
+                <li>Constructive feedback</li>
+                <li>Recognition</li>
+                <li>Coaching</li>
+              </ul>
+            </Card>
+          </div>
+        </Section>
+      </RevealOnScroll>
+
+      <RevealOnScroll>
+        <Section zone="playful">
+          <Heading level={2}>
+            Tabletop RPGs & <D20Tumble>Community Building</D20Tumble>
+          </Heading>
+          <Text>
+            At their core, tabletop role-playing games like{' '}
+            <D20Tumble>Dungeons & Dragons</D20Tumble> are about collaborative storytelling,
+            creative problem-solving, and building connections. For over a decade, I've used
+            TTRPGs as a vehicle for community building, teaching, and creating welcoming spaces.
+          </Text>
+
+          <Accordion>
+            <AccordionItem title="Dungeon Master (2014–Present)">
+              <Text>
+                Running games for diverse audiences — from complete beginners to experienced players.
+                My approach focuses on player-centered storytelling, inclusive tables, teaching
+                through play, improvisation, and shared narrative authority.
+              </Text>
+              <Text>
+                Primary system: <D20Tumble>D&D 5e</D20Tumble>, plus Pathfinder, indie systems,
+                and convention one-shots.
+              </Text>
+            </AccordionItem>
+
+            <AccordionItem title="Fantasy Flight Game Center Organized Play (2016–2018)">
+              <Text>
+                Founded a weekly public play program that introduced hundreds of people to organized{' '}
+                <D20Tumble>tabletop RPG</D20Tumble> play. Recruited and trained volunteer DMs,
+                created a DM pipeline from players to experienced game masters, and built an
+                engaged community.
+              </Text>
+              <Heading level={4} size="sm">Community Lessons</Heading>
+              <ul className={styles.lessonList}>
+                <li><strong>Lower the barrier to entry</strong> &mdash; Make it easy for newcomers</li>
+                <li><strong>Create leadership pathways</strong> &mdash; Help members grow into leaders</li>
+                <li><strong>Set clear expectations</strong> &mdash; Explicit guidelines prevent problems</li>
+                <li><strong>Celebrate contributions</strong> &mdash; Recognition motivates engagement</li>
+                <li><strong>Listen and adapt</strong> &mdash; Communities evolve based on member needs</li>
+              </ul>
+            </AccordionItem>
+
+            <AccordionItem title="Charitable Fundraising (2017–2020)">
+              <Text>
+                Organized gaming events raising funds for Gillette Children's Hospital through
+                public gamedays and convention appearances. Coordinated multi-table events,
+                recruited volunteers, and showed how hobby communities can drive meaningful impact.
+              </Text>
+            </AccordionItem>
+
+            <AccordionItem title="Adventurers League (2016–Present)">
+              <Text>
+                Consistently run public play campaigns including{' '}
+                <D20Tumble>D&D's official organized play program</D20Tumble>. Hosting regular
+                sessions, managing drop-in players, and creating memorable experiences within
+                structured constraints.
+              </Text>
+            </AccordionItem>
+          </Accordion>
+        </Section>
+      </RevealOnScroll>
+
+      <RevealOnScroll>
+        <Section zone="warm">
+          <Heading level={2}>Where It All Connects</Heading>
+          <Text>
+            Running <D20Tumble>tabletop RPGs</D20Tumble> might seem disconnected from software
+            development, but the skills overlap significantly. Facilitation, teaching complex
+            systems, improvisation, community building, and storytelling — these are the same
+            skills that power developer advocacy.
+          </Text>
+          <div className={styles.overlapGrid}>
+            <Card header={<Heading level={3} size="base">Facilitation</Heading>}>
+              <Text>Managing group dynamics, ensuring everyone participates, reading the room and adjusting on the fly.</Text>
+            </Card>
+            <Card header={<Heading level={3} size="base">Teaching</Heading>}>
+              <Text>Breaking complex systems into chunks, scaffolded learning, knowing when to simplify vs. introduce nuance.</Text>
+            </Card>
+            <Card header={<Heading level={3} size="base">Improvisation</Heading>}>
+              <Text>Responding to the unexpected while maintaining coherence — whether debugging or adapting a talk.</Text>
+            </Card>
+            <Card header={<Heading level={3} size="base">Community</Heading>}>
+              <Text>Cultivating inclusive spaces, developing leadership pipelines, enabling organic community growth.</Text>
+            </Card>
+          </div>
+        </Section>
+      </RevealOnScroll>
+    </Container>
+  )
+}

--- a/src/pages/ConnectPage.module.css
+++ b/src/pages/ConnectPage.module.css
@@ -1,0 +1,28 @@
+.goalList {
+  list-style: disc;
+  padding-left: var(--space-5);
+  font-family: var(--font-body);
+  line-height: 1.8;
+  color: var(--color-text);
+  margin-top: var(--space-3);
+}
+
+.contactGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: var(--space-4);
+}
+
+.serviceGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: var(--space-4);
+  margin-top: var(--space-4);
+}
+
+@media (max-width: 768px) {
+  .contactGrid,
+  .serviceGrid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/pages/ConnectPage.test.tsx
+++ b/src/pages/ConnectPage.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { ThemeProvider } from '../foundation/ThemeProvider'
+import { ConnectPage } from './ConnectPage'
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <ThemeProvider>
+        <ConnectPage />
+      </ThemeProvider>
+    </MemoryRouter>
+  )
+}
+
+describe('ConnectPage', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    document.documentElement.removeAttribute('data-theme')
+  })
+
+  it('renders the page heading', () => {
+    renderPage()
+    expect(screen.getByRole('heading', { name: "Let's Connect" })).toBeInTheDocument()
+  })
+
+  it('renders what I\'m looking for section', () => {
+    renderPage()
+    expect(screen.getByText("What I'm Looking For")).toBeInTheDocument()
+    expect(screen.getByText(/Create educational content/)).toBeInTheDocument()
+  })
+
+  it('renders contact methods', () => {
+    renderPage()
+    expect(screen.getByText('Get in Touch')).toBeInTheDocument()
+    expect(screen.getByText('aharasymiw@gmail.com')).toBeInTheDocument()
+    expect(screen.getByText('github.com/aharasymiw')).toBeInTheDocument()
+    expect(screen.getByText('linkedin.com/in/aharasymiw')).toBeInTheDocument()
+  })
+
+  it('renders services section', () => {
+    renderPage()
+    expect(screen.getByText('Services')).toBeInTheDocument()
+    expect(screen.getByText('Speaking')).toBeInTheDocument()
+    expect(screen.getByText('Workshops')).toBeInTheDocument()
+    expect(screen.getByText('Content')).toBeInTheDocument()
+    expect(screen.getByText('DevRel')).toBeInTheDocument()
+  })
+})

--- a/src/pages/ConnectPage.tsx
+++ b/src/pages/ConnectPage.tsx
@@ -1,0 +1,97 @@
+import { Container } from '../foundation/Container'
+import { Heading } from '../foundation/Heading'
+import { Text } from '../foundation/Text'
+import { Section } from '../components/Section'
+import { Card } from '../components/Card'
+import { Link } from '../components/Link'
+import { RevealOnScroll } from '../playground/RevealOnScroll'
+import styles from './ConnectPage.module.css'
+
+export function ConnectPage() {
+  return (
+    <Container>
+      <Section>
+        <Heading level={1}>Let's Connect</Heading>
+        <Text>
+          I'm actively seeking developer advocate roles where I can combine my passions for
+          coding, community building, and helping others learn. Whether you're looking for a
+          speaker, content creator, community builder, or team member — I'd love to hear from you.
+        </Text>
+      </Section>
+
+      <RevealOnScroll>
+        <Section zone="warm">
+          <Heading level={2}>What I'm Looking For</Heading>
+          <Text>
+            After years building systems, teaching developers, and growing communities, I'm ready
+            to combine these experiences in developer advocacy. I want to work where I can:
+          </Text>
+          <ul className={styles.goalList}>
+            <li>Create educational content that helps developers succeed</li>
+            <li>Speak at conferences and community events</li>
+            <li>Build inclusive developer communities</li>
+            <li>Provide feedback that shapes products developers love</li>
+            <li>Continue writing code while amplifying its impact through education</li>
+          </ul>
+        </Section>
+      </RevealOnScroll>
+
+      <RevealOnScroll>
+        <Section>
+          <Heading level={2}>Get in Touch</Heading>
+          <div className={styles.contactGrid}>
+            <Card glyph="@" header={<Heading level={3} size="base">Email</Heading>}>
+              <Link href="mailto:aharasymiw@gmail.com">aharasymiw@gmail.com</Link>
+            </Card>
+
+            <Card header={<Heading level={3} size="base">GitHub</Heading>}>
+              <Link href="https://github.com/aharasymiw" external>github.com/aharasymiw</Link>
+            </Card>
+
+            <Card header={<Heading level={3} size="base">LinkedIn</Heading>}>
+              <Link href="https://www.linkedin.com/in/aharasymiw/" external>linkedin.com/in/aharasymiw</Link>
+            </Card>
+
+            <Card header={<Heading level={3} size="base">Mastodon</Heading>}>
+              <Link href="https://hachyderm.io/@aharasymiw" external>hachyderm.io/@aharasymiw</Link>
+            </Card>
+
+            <Card header={<Heading level={3} size="base">YouTube</Heading>}>
+              <Link href="https://www.youtube.com/@grokthings" external>@grokthings</Link>
+            </Card>
+
+            <Card header={<Heading level={3} size="base">Blog</Heading>}>
+              <Link href="https://grokthings.com" external>grokthings.com</Link>
+            </Card>
+          </div>
+        </Section>
+      </RevealOnScroll>
+
+      <RevealOnScroll>
+        <Section zone="playful">
+          <Heading level={2}>Services</Heading>
+          <Text>
+            I bring energy, expertise, and genuine enthusiasm to every opportunity. Available for:
+          </Text>
+          <div className={styles.serviceGrid}>
+            <Card header={<Heading level={3} size="base">Speaking</Heading>}>
+              <Text>Conference talks, keynotes, meetup presentations, webinars, and podcast appearances.</Text>
+            </Card>
+            <Card header={<Heading level={3} size="base">Workshops</Heading>}>
+              <Text>Technical workshops, bootcamp modules, corporate training, and hands-on coding sessions.</Text>
+            </Card>
+            <Card header={<Heading level={3} size="base">Content</Heading>}>
+              <Text>Technical writing, video tutorials, educational materials, and documentation.</Text>
+            </Card>
+            <Card header={<Heading level={3} size="base">Community</Heading>}>
+              <Text>Community strategy, developer program design, event organizing, and advocacy.</Text>
+            </Card>
+            <Card header={<Heading level={3} size="base">DevRel</Heading>}>
+              <Text>Fractional developer relations support, product feedback loops, and developer experience.</Text>
+            </Card>
+          </div>
+        </Section>
+      </RevealOnScroll>
+    </Container>
+  )
+}

--- a/src/pages/HomePage.module.css
+++ b/src/pages/HomePage.module.css
@@ -1,0 +1,35 @@
+.sectionWithGlyph {
+  position: relative;
+}
+
+.valueList {
+  list-style: none;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  font-family: var(--font-body);
+  line-height: 1.6;
+  color: var(--color-text);
+}
+
+.valueList li {
+  padding-left: var(--space-4);
+  border-left: 2px solid var(--color-accent-warm);
+}
+
+.ctaSection {
+  text-align: center;
+}
+
+.ctaButtons {
+  display: flex;
+  gap: var(--space-4);
+  justify-content: center;
+  margin-top: var(--space-5);
+  flex-wrap: wrap;
+}
+
+.ctaButtons a {
+  text-decoration: none;
+}

--- a/src/pages/HomePage.test.tsx
+++ b/src/pages/HomePage.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { ThemeProvider } from '../foundation/ThemeProvider'
+import { HomePage } from './HomePage'
+
+function renderHomePage() {
+  return render(
+    <MemoryRouter>
+      <ThemeProvider>
+        <HomePage />
+      </ThemeProvider>
+    </MemoryRouter>
+  )
+}
+
+describe('HomePage', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    document.documentElement.removeAttribute('data-theme')
+  })
+
+  it('renders the hero tagline', () => {
+    renderHomePage()
+    expect(screen.getByText("Let's build together.")).toBeInTheDocument()
+  })
+
+  it('renders the three hero cards', () => {
+    renderHomePage()
+    expect(screen.getByText('Who')).toBeInTheDocument()
+    expect(screen.getByText('What')).toBeInTheDocument()
+    expect(screen.getByText('How')).toBeInTheDocument()
+  })
+
+  it('renders the introduction section', () => {
+    renderHomePage()
+    expect(screen.getByText("Hello! I'm Andrew.")).toBeInTheDocument()
+  })
+
+  it('renders the highlights accordion', () => {
+    renderHomePage()
+    expect(screen.getByText('Featured Highlights')).toBeInTheDocument()
+    expect(screen.getByText('Bootcamp Instructor & Software Engineer')).toBeInTheDocument()
+    expect(screen.getByText('Conference Speaker & Presenter')).toBeInTheDocument()
+    expect(screen.getByText('Content Creator & Educator')).toBeInTheDocument()
+    expect(screen.getByText('Community Builder')).toBeInTheDocument()
+  })
+
+  it('renders the DevRel value propositions', () => {
+    renderHomePage()
+    expect(screen.getByText('What I Bring to Developer Relations')).toBeInTheDocument()
+    expect(screen.getByText(/Technical Credibility/)).toBeInTheDocument()
+  })
+
+  it('renders the CTA section', () => {
+    renderHomePage()
+    expect(screen.getByText('Get in Touch')).toBeInTheDocument()
+    expect(screen.getByText('View My Work')).toBeInTheDocument()
+  })
+})

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,0 +1,135 @@
+import { Link as RouterLink } from 'react-router-dom'
+import { Container } from '../foundation/Container'
+import { Heading } from '../foundation/Heading'
+import { Text } from '../foundation/Text'
+import { HeroTagline } from '../components/HeroTagline'
+import { Section } from '../components/Section'
+import { Accordion, AccordionItem } from '../components/Accordion'
+import { Button } from '../components/Button'
+import { Link } from '../components/Link'
+import { RevealOnScroll } from '../playground/RevealOnScroll'
+import { GlyphBackground } from '../playground/GlyphBackground'
+import styles from './HomePage.module.css'
+
+export function HomePage() {
+  return (
+    <Container>
+      <HeroTagline
+        tagline="Let's build together."
+        cards={[
+          {
+            label: 'Who',
+            color: 'green',
+            content: 'A software engineer, educator, and advocate who believes technology is at its best when it brings people together.',
+          },
+          {
+            label: 'What',
+            color: 'warm',
+            content: 'Speaking, teaching, community building, and creating content that helps developers grow at every level.',
+          },
+          {
+            label: 'How',
+            color: 'playful',
+            content: 'With curiosity, collaboration, and the belief that meeting people where they are is the first step to going somewhere great.',
+          },
+        ]}
+      />
+
+      <RevealOnScroll>
+        <Section zone="calm">
+          <div className={styles.sectionWithGlyph}>
+            <GlyphBackground glyph="A" top="-10px" right="-5px" />
+            <Heading level={2}>Hello! I'm Andrew.</Heading>
+            <Text>
+              I'm a seasoned software engineer and educator seeking developer advocate opportunities
+              where I can help others grow while learning new things and collaborating to tackle
+              difficult problems. With experience spanning bootcamp instruction, senior software
+              engineering, and community building, I bring a unique perspective to developer relations.
+            </Text>
+            <Text>
+              My approach combines technical depth with genuine human connection. I've taught 500+
+              students from zero coding background to shipping full-stack applications. I've written
+              production code in Python, JavaScript, React, TypeScript, and Rust. I've given dozens
+              of public talks through Toastmasters and technical conferences.
+            </Text>
+          </div>
+        </Section>
+      </RevealOnScroll>
+
+      <RevealOnScroll delay={100}>
+        <Section>
+          <Heading level={2}>Featured Highlights</Heading>
+          <Accordion>
+            <AccordionItem title="Bootcamp Instructor & Software Engineer">
+              <Text>
+                Two years teaching full-stack web development at Prime Digital Academy, taking
+                students from "what's a variable?" to shipping production applications for real
+                clients. Specialized in PostgreSQL, Express, React, Node.js, and modern web technologies.
+              </Text>
+              <RouterLink to="/speaking">Learn more about my teaching experience</RouterLink>
+            </AccordionItem>
+
+            <AccordionItem title="Conference Speaker & Presenter">
+              <Text>
+                Featured talks include "From Passwords to Passkeys" at Minnebar 18 mainstage, plus
+                dozens of technical and professional development presentations through Toastmasters
+                and community events.
+              </Text>
+              <RouterLink to="/speaking">View my speaking portfolio</RouterLink>
+            </AccordionItem>
+
+            <AccordionItem title="Content Creator & Educator">
+              <Text>
+                Active YouTube channel with technical tutorials, blog at GrokThings.com exploring
+                web development concepts, and consistent creation of educational materials for
+                developers at all levels.
+              </Text>
+              <Text>
+                <Link href="https://www.youtube.com/@grokthings" external>Watch my YouTube tutorials</Link>
+                {' | '}
+                <Link href="https://grokthings.com" external>Read my blog</Link>
+              </Text>
+            </AccordionItem>
+
+            <AccordionItem title="Community Builder">
+              <Text>
+                Started and organized public play program at Fantasy Flight Game Center, served as
+                Toastmasters Area Director, and consistently focus on creating welcoming spaces for
+                learning and growth.
+              </Text>
+              <RouterLink to="/community">Learn about my community work</RouterLink>
+            </AccordionItem>
+          </Accordion>
+        </Section>
+      </RevealOnScroll>
+
+      <RevealOnScroll delay={200}>
+        <Section zone="warm">
+          <Heading level={2}>What I Bring to Developer Relations</Heading>
+          <ul className={styles.valueList}>
+            <li><strong>Technical Credibility:</strong> Hands-on experience across the stack, from system design to deployment</li>
+            <li><strong>Educational Excellence:</strong> Proven ability to create content that resonates with developers at all levels</li>
+            <li><strong>Communication Skills:</strong> Years of public speaking training and practice through Toastmasters</li>
+            <li><strong>Community Focus:</strong> Deep understanding of what makes developer communities thrive</li>
+            <li><strong>Content Creation:</strong> Active production of tutorials, talks, articles, and educational materials</li>
+            <li><strong>Authentic Personality:</strong> Genuine enthusiasm for technology and helping others succeed</li>
+          </ul>
+        </Section>
+      </RevealOnScroll>
+
+      <RevealOnScroll delay={300}>
+        <Section zone="playful" className={styles.ctaSection}>
+          <Heading level={2}>Let's Connect</Heading>
+          <Text>
+            I'm actively seeking developer advocate roles where I can combine my passions for
+            coding, community building, and helping others learn.
+          </Text>
+          <div className={styles.ctaButtons}>
+            <RouterLink to="/connect"><Button>Get in Touch</Button></RouterLink>
+            <RouterLink to="/portfolio"><Button variant="secondary">View My Work</Button></RouterLink>
+          </div>
+        </Section>
+      </RevealOnScroll>
+    </Container>
+  )
+}

--- a/src/pages/PortfolioPage.module.css
+++ b/src/pages/PortfolioPage.module.css
@@ -1,0 +1,28 @@
+.timeline {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-5);
+}
+
+.techList {
+  list-style: none;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  font-family: var(--font-body);
+  line-height: 1.6;
+  color: var(--color-text);
+}
+
+.projectGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: var(--space-5);
+}
+
+@media (max-width: 768px) {
+  .projectGrid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/pages/PortfolioPage.test.tsx
+++ b/src/pages/PortfolioPage.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { ThemeProvider } from '../foundation/ThemeProvider'
+import { PortfolioPage } from './PortfolioPage'
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <ThemeProvider>
+        <PortfolioPage />
+      </ThemeProvider>
+    </MemoryRouter>
+  )
+}
+
+describe('PortfolioPage', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    document.documentElement.removeAttribute('data-theme')
+  })
+
+  it('renders the page heading', () => {
+    renderPage()
+    expect(screen.getByRole('heading', { name: 'Portfolio' })).toBeInTheDocument()
+  })
+
+  it('renders work experience section', () => {
+    renderPage()
+    expect(screen.getByText('Work Experience')).toBeInTheDocument()
+  })
+
+  it('renders all three employers', () => {
+    renderPage()
+    expect(screen.getByText('Prime Digital Academy')).toBeInTheDocument()
+    expect(screen.getByText('Augeo Marketing')).toBeInTheDocument()
+    expect(screen.getByText('SPS Commerce')).toBeInTheDocument()
+  })
+
+  it('renders projects section', () => {
+    renderPage()
+    expect(screen.getByText('Projects')).toBeInTheDocument()
+    expect(screen.getByText('Full-Stack Web Apps')).toBeInTheDocument()
+    expect(screen.getByText('Developer Education Tools')).toBeInTheDocument()
+    expect(screen.getByText('Open Source')).toBeInTheDocument()
+  })
+
+  it('renders career themes', () => {
+    renderPage()
+    expect(screen.getByText('Career Themes')).toBeInTheDocument()
+    expect(screen.getByText('Building Tools That Empower Others')).toBeInTheDocument()
+    expect(screen.getByText('Leading Through Influence')).toBeInTheDocument()
+  })
+})

--- a/src/pages/PortfolioPage.tsx
+++ b/src/pages/PortfolioPage.tsx
@@ -1,0 +1,200 @@
+import { Container } from '../foundation/Container'
+import { Heading } from '../foundation/Heading'
+import { Text } from '../foundation/Text'
+import { Section } from '../components/Section'
+import { Card } from '../components/Card'
+import { Accordion, AccordionItem } from '../components/Accordion'
+import { Link } from '../components/Link'
+import { RevealOnScroll } from '../playground/RevealOnScroll'
+import styles from './PortfolioPage.module.css'
+
+export function PortfolioPage() {
+  return (
+    <Container>
+      <Section>
+        <Heading level={1}>Portfolio</Heading>
+        <Text>
+          My career reflects a consistent thread: building systems that empower people. Whether
+          writing production code, designing data pipelines, or teaching the next generation of
+          developers, I focus on creating value through thoughtful engineering and clear communication.
+        </Text>
+      </Section>
+
+      <Section>
+        <Heading level={2}>Work Experience</Heading>
+        <div className={styles.timeline}>
+          <RevealOnScroll>
+            <Card glyph="P" header={
+              <div>
+                <Heading level={3} size="xl">Prime Digital Academy</Heading>
+                <Text variant="label">Software Engineer & Instructor</Text>
+                <Text variant="muted">February 2023 &ndash; June 2025 | Remote</Text>
+              </div>
+            }>
+              <Text>
+                Full-time remote instructor teaching comprehensive full-stack web development to
+                career changers. Guided 500+ students from zero coding background to shipping
+                production applications in 20 weeks.
+              </Text>
+              <Accordion>
+                <AccordionItem title="Technical Stack">
+                  <ul className={styles.techList}>
+                    <li><strong>Frontend:</strong> HTML, CSS, JavaScript ES6+, React, MaterialUI, Tailwind CSS, Vite</li>
+                    <li><strong>Backend:</strong> Node.js, Express, PostgreSQL, REST APIs</li>
+                    <li><strong>Auth:</strong> JWT, OAuth 2.0, WebAuthn</li>
+                    <li><strong>Quality:</strong> Unit testing, integration testing, CI/CD</li>
+                  </ul>
+                </AccordionItem>
+                <AccordionItem title="Key Achievements">
+                  <ul className={styles.techList}>
+                    <li>Successfully taught 500+ students from zero to full-stack</li>
+                    <li>Developed high-quality curriculum materials and exercises</li>
+                    <li>Facilitated real client projects solving business problems</li>
+                    <li>Maintained consistently high student satisfaction ratings</li>
+                  </ul>
+                </AccordionItem>
+              </Accordion>
+            </Card>
+          </RevealOnScroll>
+
+          <RevealOnScroll delay={100}>
+            <Card glyph="A" header={
+              <div>
+                <Heading level={3} size="xl">Augeo Marketing</Heading>
+                <Text variant="label">Senior Backend Software Engineer</Text>
+                <Text variant="muted">January 2022 &ndash; December 2022</Text>
+              </div>
+            }>
+              <Text>
+                Built backend services in Rust at a fast-moving startup, navigating an immature
+                ecosystem while producing significant volumes of production code under tight timelines.
+              </Text>
+              <Accordion>
+                <AccordionItem title="Details">
+                  <ul className={styles.techList}>
+                    <li><strong>Primary Language:</strong> Rust</li>
+                    <li><strong>Infrastructure:</strong> Docker, YAML configuration</li>
+                    <li>Delivered production-ready Rust code while learning the language</li>
+                    <li>Established testing patterns that became team standards</li>
+                  </ul>
+                </AccordionItem>
+              </Accordion>
+            </Card>
+          </RevealOnScroll>
+
+          <RevealOnScroll delay={200}>
+            <Card glyph="S" header={
+              <div>
+                <Heading level={3} size="xl">SPS Commerce</Heading>
+                <Text variant="muted">May 2016 &ndash; February 2022</Text>
+              </div>
+            }>
+              <Text>
+                Nearly six years progressing from consultant to software engineer, building tools
+                that empower others and leading through influence.
+              </Text>
+              <Accordion>
+                <AccordionItem title="Software Engineer (2021–2022)">
+                  <Text>Internal tooling and platform development with TypeScript, SuiteScript. Led documentation governance and mentored junior developers.</Text>
+                </AccordionItem>
+                <AccordionItem title="Associate Software Engineer (2019–2021)">
+                  <Text>Built automated data pipelines processing millions of records with Python, AWS, Django, Snowflake. Reduced manual processing by 80%.</Text>
+                </AccordionItem>
+                <AccordionItem title="Consultant (2016–2019)">
+                  <Text>Implemented EDI integrations for retail supply chain customers. Led small distributed teams and built strong customer relationships through clear communication.</Text>
+                </AccordionItem>
+              </Accordion>
+            </Card>
+          </RevealOnScroll>
+        </div>
+      </Section>
+
+      <Section>
+        <Heading level={2}>Projects</Heading>
+        <div className={styles.projectGrid}>
+          <RevealOnScroll>
+            <Card glyph="&lt;" header={<Heading level={3} size="lg">Full-Stack Web Apps</Heading>}>
+              <Text>
+                Production applications with React, TypeScript, Node.js, PostgreSQL. Real-time
+                data sync, PWA capabilities, and accessibility-first design.
+              </Text>
+              <Link href="https://github.com/aharasymiw" external>View on GitHub</Link>
+            </Card>
+          </RevealOnScroll>
+
+          <RevealOnScroll delay={100}>
+            <Card glyph="?" header={<Heading level={3} size="lg">Developer Education Tools</Heading>}>
+              <Text>
+                Interactive learning platforms with code sandboxes, progress tracking, and
+                collaborative pair programming features.
+              </Text>
+              <Link href="https://www.youtube.com/@grokthings" external>YouTube tutorials</Link>
+              {' | '}
+              <Link href="https://grokthings.com" external>Blog</Link>
+            </Card>
+          </RevealOnScroll>
+
+          <RevealOnScroll delay={200}>
+            <Card glyph="#" header={<Heading level={3} size="lg">Open Source</Heading>}>
+              <Text>
+                Contributions across JavaScript, TypeScript, Python, and Rust. Documentation
+                improvements, bug fixes, features, and mentoring new contributors.
+              </Text>
+              <Link href="https://github.com/aharasymiw" external>GitHub profile</Link>
+            </Card>
+          </RevealOnScroll>
+
+          <RevealOnScroll delay={300}>
+            <Card glyph="~" header={<Heading level={3} size="lg">Homelab & Infrastructure</Heading>}>
+              <Text>
+                TrueNAS SCALE, Docker orchestration, Frigate NVR with Coral TPU, Prometheus/Grafana
+                monitoring. Infrastructure as code in practice.
+              </Text>
+            </Card>
+          </RevealOnScroll>
+
+          <RevealOnScroll delay={400}>
+            <Card glyph="%" header={<Heading level={3} size="lg">Data Pipelines</Heading>}>
+              <Text>
+                Python/Pandas pipelines processing millions of records daily at SPS Commerce.
+                BI dashboards that reduced manual processing by 80%.
+              </Text>
+            </Card>
+          </RevealOnScroll>
+        </div>
+      </Section>
+
+      <RevealOnScroll>
+        <Section zone="calm">
+          <Heading level={2}>Career Themes</Heading>
+          <Accordion>
+            <AccordionItem title="Building Tools That Empower Others">
+              <Text>
+                The best code I've written isn't impressive for its complexity — it's valuable
+                because it solves real problems for real people.
+              </Text>
+            </AccordionItem>
+            <AccordionItem title="Leading Through Influence">
+              <Text>
+                Much of my impact has come from leading without formal authority — sharing best
+                practices, improving documentation, and mentoring colleagues.
+              </Text>
+            </AccordionItem>
+            <AccordionItem title="Learning in Public">
+              <Text>
+                Whether picking up Rust quickly at Augeo or teaching concepts I'd just mastered
+                at Prime, I believe in transparent learning and sharing the journey.
+              </Text>
+            </AccordionItem>
+            <AccordionItem title="Communication as Core Skill">
+              <Text>
+                From consulting with retail customers to teaching complete beginners, I've learned
+                to translate between technical and business stakeholders.
+              </Text>
+            </AccordionItem>
+          </Accordion>
+        </Section>
+      </RevealOnScroll>
+    </Container>
+  )
+}

--- a/src/pages/SpeakingPage.module.css
+++ b/src/pages/SpeakingPage.module.css
@@ -1,0 +1,58 @@
+.talkGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: var(--space-5);
+}
+
+@media (max-width: 768px) {
+  .talkGrid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.topicList {
+  list-style: disc;
+  padding-left: var(--space-5);
+  font-family: var(--font-body);
+  line-height: 1.6;
+  color: var(--color-text);
+  margin-top: var(--space-3);
+}
+
+.talkList {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-5);
+}
+
+.talkEntry {
+  padding-bottom: var(--space-4);
+  border-bottom: 1px solid var(--color-bg-subtle);
+}
+
+.talkEntry:last-child {
+  border-bottom: none;
+  padding-bottom: 0;
+}
+
+.bookingSection {
+  text-align: center;
+}
+
+.topicGrid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  justify-content: center;
+  margin: var(--space-4) 0;
+}
+
+.topicTag {
+  font-family: var(--font-ui);
+  font-size: var(--text-sm);
+  padding: var(--space-1) var(--space-3);
+  border-radius: var(--radius-md);
+  background: var(--color-bg-elevated);
+  color: var(--color-text);
+  border: 1px solid var(--color-bg-subtle);
+}

--- a/src/pages/SpeakingPage.test.tsx
+++ b/src/pages/SpeakingPage.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { ThemeProvider } from '../foundation/ThemeProvider'
+import { SpeakingPage } from './SpeakingPage'
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <ThemeProvider>
+        <SpeakingPage />
+      </ThemeProvider>
+    </MemoryRouter>
+  )
+}
+
+describe('SpeakingPage', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    document.documentElement.removeAttribute('data-theme')
+  })
+
+  it('renders the page heading', () => {
+    renderPage()
+    expect(screen.getByRole('heading', { name: 'Speaking & Education' })).toBeInTheDocument()
+  })
+
+  it('renders featured presentations', () => {
+    renderPage()
+    expect(screen.getByText('Featured Presentations')).toBeInTheDocument()
+    expect(screen.getByText('From Passwords to Passkeys')).toBeInTheDocument()
+    expect(screen.getByText('The World is More Complex Than We Think')).toBeInTheDocument()
+    expect(screen.getByText('Reflecting on My Path')).toBeInTheDocument()
+  })
+
+  it('renders all talks accordion', () => {
+    renderPage()
+    expect(screen.getByText('All Talks')).toBeInTheDocument()
+    expect(screen.getByText('Professional Development')).toBeInTheDocument()
+    expect(screen.getByText('Technical Deep Dives')).toBeInTheDocument()
+    expect(screen.getByText('Community & Culture')).toBeInTheDocument()
+  })
+
+  it('renders teaching section', () => {
+    renderPage()
+    expect(screen.getByText('Teaching')).toBeInTheDocument()
+    expect(screen.getByText('Prime Digital Academy')).toBeInTheDocument()
+  })
+
+  it('renders booking section with topic tags', () => {
+    renderPage()
+    expect(screen.getByText('Book Me to Speak')).toBeInTheDocument()
+    expect(screen.getByText('Modern Web Dev')).toBeInTheDocument()
+    expect(screen.getByText('Authentication & Security')).toBeInTheDocument()
+  })
+})

--- a/src/pages/SpeakingPage.tsx
+++ b/src/pages/SpeakingPage.tsx
@@ -1,0 +1,200 @@
+import { Link as RouterLink } from 'react-router-dom'
+import { Container } from '../foundation/Container'
+import { Heading } from '../foundation/Heading'
+import { Text } from '../foundation/Text'
+import { Section } from '../components/Section'
+import { Card } from '../components/Card'
+import { Accordion, AccordionItem } from '../components/Accordion'
+import { Button } from '../components/Button'
+import { Link } from '../components/Link'
+import { RevealOnScroll } from '../playground/RevealOnScroll'
+import styles from './SpeakingPage.module.css'
+
+export function SpeakingPage() {
+  return (
+    <Container>
+      <Section>
+        <Heading level={1}>Speaking & Education</Heading>
+        <Text>
+          Great technical talks do more than convey information — they inspire action, challenge
+          assumptions, and create connections. My approach combines deep technical knowledge with
+          accessible explanations, ensuring both beginners and experts leave with valuable insights.
+        </Text>
+      </Section>
+
+      <Section>
+        <Heading level={2}>Featured Presentations</Heading>
+        <div className={styles.talkGrid}>
+          <RevealOnScroll>
+            <Card glyph="K" header={
+              <div>
+                <Heading level={3} size="lg">From Passwords to Passkeys</Heading>
+                <Text variant="label">Minnebar 18 &mdash; Mainstage (2024)</Text>
+              </div>
+            }>
+              <Text>
+                Delivered to a packed auditorium at Minnesota's largest technology unconference.
+                Explored the journey from traditional passwords to modern passwordless authentication.
+              </Text>
+              <ul className={styles.topicList}>
+                <li>WebAuthn and FIDO2 standards</li>
+                <li>Implementation strategies for passkeys</li>
+                <li>UX considerations in authentication</li>
+                <li>Migration paths for existing apps</li>
+              </ul>
+            </Card>
+          </RevealOnScroll>
+
+          <RevealOnScroll delay={100}>
+            <Card glyph="C" header={
+              <div>
+                <Heading level={3} size="lg">The World is More Complex Than We Think</Heading>
+                <Text variant="label">2024</Text>
+              </div>
+            }>
+              <Text>
+                Challenging developers to embrace complexity rather than oversimplifying problems,
+                leading to more robust and thoughtful solutions.
+              </Text>
+            </Card>
+          </RevealOnScroll>
+
+          <RevealOnScroll delay={200}>
+            <Card glyph="R" header={
+              <div>
+                <Heading level={3} size="lg">Reflecting on My Path</Heading>
+                <Text variant="label">2024</Text>
+              </div>
+            }>
+              <Text>
+                An honest exploration of career transitions, from mathematics to software engineering
+                to education, and the lessons learned along the way.
+              </Text>
+            </Card>
+          </RevealOnScroll>
+        </div>
+      </Section>
+
+      <RevealOnScroll>
+        <Section>
+          <Heading level={2}>All Talks</Heading>
+          <Accordion>
+            <AccordionItem title="Professional Development">
+              <div className={styles.talkList}>
+                <div className={styles.talkEntry}>
+                  <Heading level={4} size="base">When to Say Yes! &mdash; The Art of Taking on New Projects</Heading>
+                  <Text variant="muted">2022</Text>
+                  <Text>Strategic advice for evaluating opportunities and managing professional growth.</Text>
+                </div>
+                <div className={styles.talkEntry}>
+                  <Heading level={4} size="base">I Want a Good, Clean Fight &mdash; How to Disagree Professionally</Heading>
+                  <Text variant="muted">2022</Text>
+                  <Text>Essential skills for navigating technical disagreements while maintaining positive relationships.</Text>
+                </div>
+                <div className={styles.talkEntry}>
+                  <Heading level={4} size="base">Bootstrapping Remote Leadership</Heading>
+                  <Text variant="muted">2023</Text>
+                  <Text>Candid discussion of leading remote teams, sharing both successes and ongoing challenges.</Text>
+                </div>
+              </div>
+            </AccordionItem>
+
+            <AccordionItem title="Technical Deep Dives">
+              <div className={styles.talkList}>
+                <div className={styles.talkEntry}>
+                  <Heading level={4} size="base">The Life-Changing Magic of Bubbling Up</Heading>
+                  <Text variant="muted">2021</Text>
+                  <Text>Comprehensive exploration of error handling patterns in modern applications.</Text>
+                </div>
+                <div className={styles.talkEntry}>
+                  <Heading level={4} size="base">Digital Safety Practices</Heading>
+                  <Text variant="muted">2023</Text>
+                  <Text>Practical security guidance for developers and non-technical users.</Text>
+                </div>
+                <div className={styles.talkEntry}>
+                  <Heading level={4} size="base">Artisans of Code</Heading>
+                  <Text variant="muted">2023</Text>
+                  <Text>Exploring the craft of software development beyond mere functionality.</Text>
+                </div>
+              </div>
+            </AccordionItem>
+
+            <AccordionItem title="Community & Culture">
+              <div className={styles.talkList}>
+                <div className={styles.talkEntry}>
+                  <Heading level={4} size="base">What I Do: Describing the Role of a Software Engineer</Heading>
+                  <Text variant="muted">2022</Text>
+                  <Text>Demystifying software engineering for non-technical audiences.</Text>
+                </div>
+                <div className={styles.talkEntry}>
+                  <Heading level={4} size="base">Zoom 2.0 &mdash; Best Practices, Tips, and Tricks</Heading>
+                  <Text variant="muted">2021</Text>
+                  <Text>Practical guidance for effective remote communication.</Text>
+                </div>
+                <div className={styles.talkEntry}>
+                  <Heading level={4} size="base">Early Lessons in Leadership</Heading>
+                  <Text variant="muted">2021</Text>
+                  <Text>Insights from first leadership experiences and unexpected challenges.</Text>
+                </div>
+              </div>
+            </AccordionItem>
+          </Accordion>
+        </Section>
+      </RevealOnScroll>
+
+      <RevealOnScroll>
+        <Section zone="warm">
+          <Heading level={2}>Teaching</Heading>
+          <Text>
+            I believe in meeting learners where they are and guiding them to where they want to be.
+            My approach combines empathy, practical application, and continuous encouragement.
+          </Text>
+
+          <Heading level={3}>Prime Digital Academy</Heading>
+          <Text>
+            Full-time remote instructor teaching comprehensive full-stack web development to career
+            changers with zero coding background. Guided 500+ students from "what is a variable?" to
+            shipping production applications in just 20 weeks.
+          </Text>
+
+          <Heading level={3}>Content Creation</Heading>
+          <Text>
+            <Link href="https://www.youtube.com/@grokthings" external>YouTube channel</Link> with
+            technical tutorials for developers at all levels, plus in-depth articles at{' '}
+            <Link href="https://grokthings.com" external>GrokThings</Link> covering algorithms,
+            JavaScript, architecture, and learning strategies.
+          </Text>
+
+          <Heading level={3}>Mentorship</Heading>
+          <Text>
+            One-on-one coaching, code review, career guidance, interview prep, and open source
+            guidance. From college tutoring at UW-Milwaukee to mentoring bootcamp graduates.
+          </Text>
+        </Section>
+      </RevealOnScroll>
+
+      <RevealOnScroll>
+        <Section zone="playful" className={styles.bookingSection}>
+          <Heading level={2}>Book Me to Speak</Heading>
+          <Text>
+            I bring energy, expertise, and genuine enthusiasm to every speaking opportunity.
+            Available for conferences, workshops, podcasts, webinars, meetups, and corporate training.
+          </Text>
+          <div className={styles.topicGrid}>
+            <span className={styles.topicTag}>Modern Web Dev</span>
+            <span className={styles.topicTag}>Authentication & Security</span>
+            <span className={styles.topicTag}>Developer Education</span>
+            <span className={styles.topicTag}>Career Transitions</span>
+            <span className={styles.topicTag}>Remote Work</span>
+            <span className={styles.topicTag}>Community Building</span>
+            <span className={styles.topicTag}>Communication</span>
+            <span className={styles.topicTag}>Bootcamp to Career</span>
+          </div>
+          <RouterLink to="/connect" style={{ textDecoration: 'none' }}>
+            <Button>Contact Me</Button>
+          </RouterLink>
+        </Section>
+      </RevealOnScroll>
+    </Container>
+  )
+}

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -1,5 +1,17 @@
 import '@testing-library/jest-dom'
 
+// Mock IntersectionObserver for jsdom
+class MockIntersectionObserver {
+  observe = vi.fn()
+  unobserve = vi.fn()
+  disconnect = vi.fn()
+  constructor() {}
+}
+Object.defineProperty(window, 'IntersectionObserver', {
+  writable: true,
+  value: MockIntersectionObserver,
+})
+
 // Mock window.matchMedia for jsdom
 Object.defineProperty(window, 'matchMedia', {
   writable: true,


### PR DESCRIPTION
## Summary

- Add React Router with 5 page components (Homepage, Portfolio, Speaking & Education, Community, Connect) plus 404 route
- Migrate all content from legacy HTML files into React components using the existing design system
- Integrate easter eggs: Konami confetti, Gravy snail, SunsetTransition, D20Tumble, PartyMode, FooterTaglines, GlyphBackground
- Add client-side navigation via `linkComponent` prop on NavBar, scroll-to-top on route change
- 34 new tests (222 total), all passing

## Test plan

- [x] `npm run build` passes with zero errors
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint src/App.tsx src/pages/` clean
- [x] `npx vitest run` — 222/222 tests passing
- [ ] Manual: navigate all 5 routes in browser
- [ ] Manual: toggle theme, verify dark/light modes
- [ ] Manual: resize for mobile responsive layout
- [ ] Manual: trigger easter eggs (Konami code, idle for Gravy, hover D&D refs, click footer year)

🤖 Generated with [Claude Code](https://claude.com/claude-code)